### PR TITLE
Fixes for python 3.5

### DIFF
--- a/lib/python3-function.js
+++ b/lib/python3-function.js
@@ -113,7 +113,7 @@ class Msg(object):
 
     @classmethod
     def loads(cls, json_string):
-        return cls(**json.loads(json_string))
+        return cls(**json.loads(json_string).decode('utf-8'))
 
 
 class Node(object):
@@ -155,7 +155,7 @@ while True:
     raw_msg = channel.readline()
     if not raw_msg:
         raise RuntimeError('Received EOF!')
-    msg = json.loads(raw_msg)
+    msg = json.loads(raw_msg.decode('utf-8'))
     msgid = msg["_msgid"]
     node = Node(msgid, channel)
     res_msgs = python_function(msg)


### PR DESCRIPTION
I was trying to run that node on python 3.5 and got error "JSON object must be str, not 'bytes'". I've found that solution on Stack Exchange and it worked well. I'm not a Python programmer so I'm not sure if its 100% correct.