### PR TITLE
BUG: python function node is delete msg.res

### DIFF
--- a/lib/python3-function.js
+++ b/lib/python3-function.js
@@ -76,6 +76,14 @@ module.exports = function (RED) {
             }
         }
         if (msgCount > 0) {
+            // Restore REQ object if it exists.
+            if (self.req !== undefined){
+              msgs[0].req = self.req;
+            }
+            // Restore RES object if it exists.
+            if (self.res !== undefined){
+              msgs[0].res = self.res;
+            }
             self.send(msgs);
         }
     }
@@ -165,6 +173,14 @@ while True:
         };
         spawnFn(self);
         self.on('input', function (msg) {
+            // Save REQ object if it exists.
+            if (msg.req !== undefined){
+              self.req = msg.req;
+            }
+            // Save RES object if it exists.
+            if (msg.res !== undefined){
+              self.res = msg.res;
+            }
             var cache = [];
             jsonMsg = JSON.stringify(msg, function (key, value) {
                 if (typeof value === 'object' && value !== null) {


### PR DESCRIPTION
There is a bug: the Python 3 function node will delete all content in msg.res (e.g. by using it after a http in node)
In the Python (2) function node project was already a BUG fix (https://github.com/arnauorriols/node-red-contrib-python-function/commit/3aaea92b365111070f8f8839f226f79b62b255ab)